### PR TITLE
chore: eliminate or operator in find function

### DIFF
--- a/src/lib/multipart-parser.ts
+++ b/src/lib/multipart-parser.ts
@@ -338,7 +338,7 @@ function find(
       return k + 1;
     }
 
-    i += skipTable[byteAt(i)] || pattern.length;
+    i += skipTable[byteAt(i)];
   }
 
   return -1;


### PR DESCRIPTION
This improves performance by ~42% for large files.

Before
<img width="689" alt="image" src="https://github.com/user-attachments/assets/090a841b-662e-4816-a719-38e3044fe118">

After
<img width="689" alt="image" src="https://github.com/user-attachments/assets/ce8ed6ad-90e3-4e66-910e-4b43a57fb977">
