### PR TITLE
add multipasta to bench

### DIFF
--- a/bench/package.json
+++ b/bench/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@fastify/busboy": "^3.0.0",
     "@mjackson/multipart-parser": "workspace:*",
-    "busboy": "^1.6.0"
+    "busboy": "^1.6.0",
+    "multipasta": "^0.2.4"
   },
   "devDependencies": {
     "@types/bun": "^1.1.6",

--- a/bench/parsers/multipasta.ts
+++ b/bench/parsers/multipasta.ts
@@ -1,0 +1,24 @@
+import * as Multipasta from 'multipasta';
+
+import { MultipartMessage } from '../messages.js';
+
+export function parse(message: MultipartMessage): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const start = performance.now();
+    const parser = Multipasta.make({
+      headers: { 'content-type': `multipart/form-data; boundary=${message.boundary}` },
+      onDone() {
+        resolve(performance.now() - start);
+      },
+      onError: reject,
+      onFile(_info) {
+        return (_chunk) => {};
+      },
+      onField() {},
+    });
+    for (const chunk of message.generateChunks()) {
+      parser.write(chunk);
+    }
+    parser.end();
+  });
+}

--- a/bench/runner.ts
+++ b/bench/runner.ts
@@ -5,6 +5,7 @@ import * as messages from './messages.js';
 import * as busboy from './parsers/busboy.js';
 import * as fastifyBusboy from './parsers/fastify-busboy.js';
 import * as multipartParser from './parsers/multipart-parser.js';
+import * as multipasta from './parsers/multipasta.js';
 
 const benchmarks = [
   { name: '1 small file', message: messages.oneSmallFile },
@@ -59,6 +60,9 @@ async function runBenchmarks(parserName?: string): Promise<BenchmarkResults> {
   }
   if (parserName === 'fastify-busboy' || parserName === undefined) {
     results['@fastify/busboy'] = await runParserBenchmarks(fastifyBusboy);
+  }
+  if (parserName === 'multipasta' || parserName === undefined) {
+    results['multipasta'] = await runParserBenchmarks(multipasta);
   }
 
   return results;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       busboy:
         specifier: ^1.6.0
         version: 1.6.0
+      multipasta:
+        specifier: ^0.2.4
+        version: 0.2.4
     devDependencies:
       '@types/bun':
         specifier: ^1.1.6
@@ -565,6 +568,9 @@ packages:
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  multipasta@0.2.4:
+    resolution: {integrity: sha512-uS6VKZou4iDU4evtrNKGvRqgqkFtPdjG/ql9XDICfnzKEedgf0OZ+oEhM0ps0FL5IVFhkIzOBgLV/KpEEJMthw==}
 
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
@@ -1190,6 +1196,8 @@ snapshots:
   mkdirp@3.0.1: {}
 
   ms@2.1.2: {}
+
+  multipasta@0.2.4: {}
 
   mustache@4.2.0: {}
 


### PR DESCRIPTION
Switches to testing against random binary data to better simulate binary uploads. Also increased chunk size to reflect node's high watermark.

Will leave this as a draft as I added a flake.nix which may not be wanted :)