### PR TITLE
perf: BMHS logic, simplify and skip more aggressively

### DIFF
--- a/src/lib/buffer-utils.ts
+++ b/src/lib/buffer-utils.ts
@@ -37,7 +37,7 @@ export function indexOf(
     }
 
     if (i + needle.length === totalLength) {
-      break;
+      return -1;
     }
   }
 

--- a/src/lib/buffer-utils.ts
+++ b/src/lib/buffer-utils.ts
@@ -23,36 +23,32 @@ export function indexOf(
   needle: Uint8Array,
   skipTable = computeSkipTable(needle),
 ): number {
-  let headLength = head.length;
-  let totalLength = headLength + tail.length;
-  let i = needle.length - 1;
+  let totalLength = head.length + tail.length;
 
-  while (i < totalLength) {
-    let j = needle.length - 1;
-    let k = i;
 
-    while (j >= 0 && (k < headLength ? head[k] : tail[k - headLength]) === needle[j]) {
-      j--;
-      k--;
+  for (let i = 0; i + needle.length <= totalLength; i += skipTable[(i + needle.length < head.length ? head[i + needle.length] : tail[i + needle.length - head.length])]) {
+    let p = 0;
+
+    while (p !== needle.length && needle[p] === (i + p < head.length ? head[i + p] : tail[i + p - head.length])) {
+      ++p;
     }
 
-    if (j === -1) {
-      return k + 1;
+    if (p === needle.length) {
+      return i;
     }
-
-    i += skipTable[i < headLength ? head[i] : tail[i - headLength]];
   }
 
-  return -1; // Not found
+  return -1;
 }
 
 export function computeSkipTable(needle: Uint8Array): Uint8Array {
-  let table = new Uint8Array(256).fill(needle.length);
-  let lastIndex = needle.length - 1;
+  let table = new Uint8Array(256).fill(needle.length + 1);
 
-  for (let i = 0; i < lastIndex; ++i) {
-    table[needle[i]] = lastIndex - i;
+  for (let i = 0; i < needle.length; ++i) {
+    table[needle[i]] = needle.length - i;
   }
+
+  console.log(table);
 
   return table;
 }

--- a/src/lib/buffer-utils.ts
+++ b/src/lib/buffer-utils.ts
@@ -25,7 +25,6 @@ export function indexOf(
 ): number {
   let totalLength = head.length + tail.length;
 
-
   for (let i = 0; i + needle.length <= totalLength; i += skipTable[(i + needle.length < head.length ? head[i + needle.length] : tail[i + needle.length - head.length])]) {
     let p = 0;
 
@@ -35,6 +34,10 @@ export function indexOf(
 
     if (p === needle.length) {
       return i;
+    }
+
+    if (i + needle.length === totalLength) {
+      break;
     }
   }
 
@@ -47,8 +50,6 @@ export function computeSkipTable(needle: Uint8Array): Uint8Array {
   for (let i = 0; i < needle.length; ++i) {
     table[needle[i]] = needle.length - i;
   }
-
-  console.log(table);
 
   return table;
 }


### PR DESCRIPTION
Hey, this looks awesome!

You beat me to market here, I was working on a similar thing for `@fastify/multipart` :)

This version of the algorithm can do the same search in less cycles in most cases and aligns more closely the Sunday's variant of BMH, it's hard to benchmark though

We also skip more aggressively (`patternLength + 1` instead of `patternLength`) for each missed character

```cpp
sunday(const char *p) : p(p), m(strlen(p)) {
  skip.assign(0x100, m+1);
  for (int i = 0; i < m; ++i)
    skip[p[i]] = m - i;
}

vector<int> match(const char s[]) {
  int n = strlen(s);
  vector<int> occur;
  for (int i = 0; i <= n - m; ) {
    if (memcmp(p, s + i, m) == 0) {
      occur.push_back(i);
    }
    i += skip[s[i + m]];
  }
  return occur;
}
```

https://www.cs.emory.edu/~cheung/Courses/253/Syllabus/Text/Docs/Boyer-Moore-variants.pdf