### PR TITLE
docs: remove `$` from shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ The goals of this project are:
 Install from [npm](https://www.npmjs.com/):
 
 ```sh
-$ npm install @mjackson/multipart-parser
+npm install @mjackson/multipart-parser
 ```
 
 Or install from [JSR](https://jsr.io/):
 
 ```sh
-$ deno add @mjackson/multipart-parser
+deno add @mjackson/multipart-parser
 ```
 
 ## Usage


### PR DESCRIPTION
So you don't have to remove them when triple clicking the line to copy or clicking the copy button in GitHub:

![image](https://github.com/user-attachments/assets/4ac55c06-b5ca-4d3c-be34-ee000829bd79)

Right now, what's copied when you click that is:

```
$ npm install @mjackson/multipart-parser
```

But I'd rather not have to remove the `$ ` before I can execute the command.