### PR TITLE
Add type export modifier to `MultipartParserOptions` interface

### DIFF
--- a/src/multipart-parser.ts
+++ b/src/multipart-parser.ts
@@ -4,7 +4,7 @@ export {
   parseMultipartRequest,
   parseMultipart,
   MultipartParseError,
-  MultipartParserOptions,
+  type MultipartParserOptions,
   MultipartParser,
   MultipartPart,
 } from './lib/multipart.js';


### PR DESCRIPTION
Its appers that with deno and using the jsr package, if the named export does not contain the type keyword, it throw an error of `The requested module './lib/multipart.ts' does not provide an export named 'MultipartParserOptions'`.

![Screenshot from 2024-08-11 16-03-35](https://github.com/user-attachments/assets/81f8174c-e60e-437d-a8ea-2480deeac821)


Adding the type keyword seems to fix it.
This was tested by creating a ts file in the root of the project with the code;
```ts
import {parseMultipartRequest} from "./src/multipart-parser.ts":

console.log(parseMultipartRequest)
```
run it using deno (had to also change imports from .js to .ts) and was able to reproduce the issue above and fix it.